### PR TITLE
boell foundation

### DIFF
--- a/grrbl_blacklist.cf
+++ b/grrbl_blacklist.cf
@@ -655,6 +655,7 @@ blacklist_from	system@gothess.gr
 blacklist_from	info@gozeekler.gr
 blacklist_from	*@gps-com.gr
 blacklist_from	info@gpstracker.gr
+blacklist_from	info@gr.boell.org
 blacklist_from	info@grabit.gr
 blacklist_from	noreplay@grammiki.gr
 blacklist_from	newsletter@grapsa.edu.gr


### PR DESCRIPTION
unsubscribe link responds with 404, so, not really working.
---
Return-Path: <bounce+96701@bounce-eu2.crsend.com>
X-Original-To: $email
Delivered-To: $email
Received: from mx010.de-mx.crsend.com (mx010.de-mx.crsend.com [178.77.121.171])
	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
	(No client certificate requested)
	by $server (Postfix) with ESMTPS id B82762A1C335
	for <$email>; Wed, 18 Apr 2018 11:50:25 +0300 (EEST)
Received: from 002.de-mx.crsend.com (002.de-mx.crsend.com [178.77.121.162])
	by mx010.de-mx.crsend.com (Postfix) with ESMTP id C533B443447
	for <$email>; Wed, 18 Apr 2018 10:31:00 +0200 (CEST)
Received: from cron-eu2.crsend.com (cron-eu2.crsend.com [178.77.121.135])
	by 002.de-mx.crsend.com (Postfix) with ESMTP id 73F614206F3
	for <$email>; Wed, 18 Apr 2018 10:30:57 +0200 (CEST)
Date: Wed, 18 Apr 2018 10:30:57 +0200
From: Heinrich-Boell-Stiftung-Greece <info@gr.boell.org>
Subject: UPCOMING EVENTS_HEINRICH BOELL FOUNDATION GREECE_APRIL-MAY 2018
Message-ID: <5c5e33d0888b4908cbe44398f36fc186@cron-eu2.crsend.com>